### PR TITLE
updated default popover css

### DIFF
--- a/app/webroot/css/main.css
+++ b/app/webroot/css/main.css
@@ -1702,7 +1702,9 @@ table.table.table-striped tr.deleted_row td {
 }
 
 .popover {
-	max-width:33%;
+	max-width:25%;
+        max-height: 33%;
+        overflow: hidden;
 }
 
 .checkbox input[type=checkbox] {


### PR DESCRIPTION
Large results from a hover can make the popover difficult to use. I've limited the width, height, and amount of information the popover will display by default.

## Generic requirements in order to contribute to MISP:

* One Pull Request per fix/feature/change/...
* Keep the amount of commits per PR as small as possible: if for any reason, you need to fix your commit after the pull request, please squash the changes in one single commit (or tell us why not)
* Always make sure it is mergeable in the default branch (as of today 2016-06-03: branch 2.4)
* Please make sure Travis CI works on this request, or update the test cases if needed
* Any major changes adding a functionality should be disabled by default in the config


#### What does it do?

If it fixes an existing issue, please use github syntax: `#<IssueID>`

#### Questions

- [ ] Does it require a DB change?
- [X] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
